### PR TITLE
rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM ubuntu:16.04
-MAINTAINER : g6n
+MAINTAINER : g6nuk
 RUN apt-get update && \
     apt-get install -y wget cron && \
     wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
     echo deb http://packages.elastic.co/curator/4/debian stable main > /etc/apt/sources.list.d/curator.list && \
     apt-get update && \
     apt-get install -y elasticsearch-curator && \
-    echo "actions: \n  1: \n    action: delete_indices \n    description: \"Delete filebeat indices\" \n    options: \n      timeout_override: \n      continue_if_exception: False \n      disable_action: False \n    filters: \n     - filtertype: pattern \n       kind: prefix \n       value: filebeat- \n       exclude: \n     - filtertype: age \n       source: name \n       direction: older \n       timestring: '%Y.%m.%d' \n       unit: days \n       unit_count: 15 \n       field: \n       stats_result: \n       epoch: \n       exclude: False \n \n  2: \n    action: delete_indices \n    description: \"Delete LPT indices\" \n    options: \n      timeout_override: \n      continue_if_exception: False \n      disable_action: False \n    filters: \n     - filtertype: pattern \n       kind: prefix \n       value: lpt- \n       exclude: \n     - filtertype: age \n       source: name \n       direction: older \n       timestring: '%Y.%m.%d' \n       unit: days \n       unit_count: 90 \n       field: \n       stats_result: \n       epoch: \n       exclude: False \n " > /tmp/action.yaml && \
-    echo "client: \n  hosts: \n    - elas \n  port: 9200 \n  url_prefix: \n  use_ssl: False \n  certificate: \n  client_cert: \n  client_key: \n  ssl_no_validate: False \n  http_auth: \n  timeout: 30  \n  master_only: False \n  \nlogging: \n  loglevel: INFO \n  logfile: \n  logformat: default \n  blacklist: ['elasticsearch', 'urllib3'] \n" > /tmp/config.yaml && \
+    apt-get clean
     echo "1 * * * * LC_ALL=C.UTF-8 /usr/bin/curator --config /tmp/config.yaml /tmp/action.yaml >> /var/log/cron.log \n" >> /var/curator.cron && \ 
     crontab /var/curator.cron && \
     echo "cron.log entry \n" >> /var/log/cron.log
 
+ADD config.yaml /tmp/config.yaml
+ADD actions.yaml /tmp/actions.yaml
 CMD service cron start && tail -f /var/log/cron.log

--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 # Curator
 
 This Dockerfile is based on Ubuntu 16.04
-It installs curator from the debian 4.0 elastic search repo.
+It installs the latest available curator package from the debian 4.0 elastic search repo.
 
-It runs curator as a daily cron job at 01:01
+It runs curator as a hourly cron job at n:01
 
-It requires 5 environmental variables:
-curator_hosts=<hostnames> e.g. elasticsearch
-curator_port=<portname> e.g. 9200 (only used if hosts do not have a hostname:portname markup
-curator_delete_unit=<unit of time> e.g. days
-curator_delete_unit_count=<amount of unit of time> e.g. 14
-curator_index_prefix=<nameof the index> #e.g. logstash-
+Curator requires two files to run.
+action.yaml and config.yaml
+both these files are included in this repo, but are rather specific.
 
-It assumes a YYYY.MM.DD date format at the end of the index name.
+When using Kubernetes, substitute these files with a configmap that while set the appropiate settings for your indexes
+and overwirte the files included in the build.
+
+The default build has the following settings:
+  action.yaml
+    action 1 looks for indexes named filebeat-*
+    that are older than 14 days
+    and will delete these
+
+    action2 looks for indexes named lpt-*
+    that are older then 90 days
+    and will delete these
+
+  config.yaml
+   sets the elasticsearch host to elas
+   sets the elasticsearch host port to 9200
+   uses no authentication or transport security
+   logs INFO messages to the default output (defined in the Dockerfile)
+
+

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,45 @@
+actions:   
+1: 
+  action: delete_indices 
+  description: \"Delete filebeat indices\" 
+  options: \n      timeout_override: 
+  continue_if_exception: False 
+  disable_action: False 
+  filters: 
+  - filtertype: pattern 
+    kind: prefix 
+    value: filebeat- 
+    exclude: 
+  - filtertype: age 
+    source: name 
+    direction: older 
+    timestring: '%Y.%m.%d' 
+    unit: days 
+    unit_count: 14 
+    field: 
+    stats_result: 
+    epoch: 
+    exclude: False 
+	
+2: 
+  action: delete_indices 
+  description: \"Delete LPT indices\" 
+  options: \n      timeout_override: 
+  continue_if_exception: False 
+  disable_action: False 
+  filters: 
+  - filtertype: pattern 
+    kind: prefix 
+    value: lpt- 
+    exclude: 
+  - filtertype: age 
+    source: name 
+    direction: older 
+    timestring: '%Y.%m.%d' 
+    unit: days 
+    unit_count: 90 
+    field: 
+    stats_result: 
+    epoch: 
+    exclude: False 
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+client:
+  hosts:
+  - elas   
+  port: 9200 
+  url_prefix: 
+  use_ssl: False 
+  certificate: 
+  client_cert: 
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30  
+  master_only: False
+logging: 
+  loglevel: INFO 
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3'] 
+  


### PR DESCRIPTION
Rebuild this version to clean itself from cached for a smaller image,
and to use input files (now included) which can be easily overwritten
by config maps in Kubernetes.